### PR TITLE
Docker/Nginx: proxy de API y Socket.IO configurable por BACKEND_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 RUN npm ci
 
 COPY . .
-RUN npm run build -- --configuration production
+RUN npx ng build --configuration production
 
 FROM nginx:1.27-alpine
 
@@ -14,16 +14,8 @@ FROM nginx:1.27-alpine
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /app/dist/proyecto-software-front/browser /usr/share/nginx/html
 
-# Minimal SPA fallback to avoid 404 on refresh.
-# Angular uses client-side routing, so we need to serve index.html for all routes.
-RUN echo 'server { \
-	listen 80; \
-	location / { \
-		root /usr/share/nginx/html; \
-		index index.html index.htm; \
-		try_files $uri $uri/ /index.html; \
-	} \
-}' > /etc/nginx/conf.d/default.conf
+# Let nginx official entrypoint render the template with env vars.
+COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 80
 

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    # Proxy API calls to the backend URL defined at container runtime.
+    location /api/ {
+        proxy_pass ${BACKEND_URL};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy Socket.IO websocket transport to the same backend.
+    location /socket.io/ {
+        proxy_pass ${BACKEND_URL};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
+
+    # SPA fallback for Angular routes.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Qué incluye esta PR
1. Ajuste del contenedor de frontend para build de Angular en multi-stage y servido estático con Nginx.
2. Configuración de Nginx para actuar como reverse proxy de:
- /api
- /socket.io
3. Parametrización del backend mediante variable de entorno BACKEND_URL en runtime.

## Qué NO incluye esta PR
1. No se modifica lógica de aplicación Angular.
2. No se modifican contratos del backend.
3. No se añaden cambios funcionales en servicios de frontend (solo infraestructura de despliegue).

## Sugerencias del Frontend
- Frontend: definir fallback de socket al mismo origen público de la app para evitar dependencias de host/puerto hardcodeados cuando el backend no envía socketURL. Archivo afectado: `dixit-realtime.ts`.
- Frontend en desarrollo: añadir proxy de WebSocket para Socket.IO en local (ruta /socket.io con ws true), igual que ya se hace con /api. Archivo afectado: `proxy.conf.json`.

## Contexto técnico
1. El backend actualmente no devuelve socketURL.
2. Para ese escenario, esta PR se centra en resolver en capa de infraestructura (proxy por Nginx) sin tocar código de otros módulos.

## Cómo configurar (HECHO)
1. Definir BACKEND_URL en el entorno de despliegue.
2. Inyectar BACKEND_URL en el contenedor frontend en runtime.

> [!NOTE]
> No he podido testear nada.